### PR TITLE
docs: add npm package readmes

### DIFF
--- a/packages/create-rejoice-app/README.md
+++ b/packages/create-rejoice-app/README.md
@@ -1,0 +1,58 @@
+# create-rejoice-app
+
+Scaffold a batteries-included React app powered by `rejoice-js`.
+
+The generated app comes prewired with:
+
+- Ant Design 5
+- styled-components
+- Zustand
+- built-in light/dark theme support
+- zero-config JSX via `rejoice-js`
+- optional React Router setup
+- TypeScript + Vite
+
+## Quick start
+
+```bash
+npx create-rejoice-app my-app
+cd my-app
+pnpm install
+pnpm dev
+```
+
+You can also run it without arguments and answer the prompts:
+
+```bash
+npx create-rejoice-app
+```
+
+## What the CLI asks for
+
+- project name
+- whether to include React Router v6
+- default theme: light or dark
+- package manager: `pnpm`, `npm`, or `yarn`
+- whether to initialize a git repository
+
+## Generated app basics
+
+The scaffolded app is set up to use `rejoice-js` as the JSX import source and includes:
+
+- `RejoiceProvider` for theme wiring
+- Ant Design components
+- `styled` from styled-components
+- Zustand state store examples
+- starter app structure ready for agent-driven edits
+
+## Workspace note
+
+If you scaffold inside an existing `pnpm` workspace, install dependencies in the generated app with:
+
+```bash
+pnpm install --ignore-workspace
+```
+
+## Related package
+
+If you want to use the runtime package directly, see [`rejoice-js`](https://www.npmjs.com/package/rejoice-js).

--- a/packages/create-rejoice-app/package.json
+++ b/packages/create-rejoice-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-rejoice-app",
   "version": "0.1.0",
+  "description": "Scaffold a batteries-included React app powered by rejoice-js, Ant Design, styled-components, Zustand, and built-in theming.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -8,7 +9,26 @@
     "clean": "rm -rf dist"
   },
   "bin": { "create-rejoice-app": "./dist/index.js" },
-  "files": ["dist", "templates"],
+  "files": ["dist", "templates", "README.md"],
+  "keywords": [
+    "react",
+    "scaffold",
+    "cli",
+    "vite",
+    "antd",
+    "styled-components",
+    "zustand"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AviroopPaul/rejoice-js.git",
+    "directory": "packages/create-rejoice-app"
+  },
+  "homepage": "https://github.com/AviroopPaul/rejoice-js#readme",
+  "bugs": {
+    "url": "https://github.com/AviroopPaul/rejoice-js/issues"
+  },
+  "license": "MIT",
   "dependencies": {
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",

--- a/packages/rejoice/README.md
+++ b/packages/rejoice/README.md
@@ -1,0 +1,59 @@
+# rejoice-js
+
+`rejoice-js` is a batteries-included React package for building apps with a stable, opinionated stack.
+
+It re-exports React plus:
+
+- Ant Design 5
+- styled-components
+- Zustand
+- light/dark theme helpers
+- JSX runtime helpers
+
+## Install
+
+```bash
+pnpm add rejoice-js react react-dom
+```
+
+## Basic usage
+
+```tsx
+import { Button, RejoiceProvider, createRoot, styled, useTheme } from "rejoice-js";
+
+const Box = styled.div`
+  padding: ${({ theme }) => theme.spacing(3)};
+  background: ${({ theme }) => theme.colors.surface};
+`;
+
+function App() {
+  const { isDarkMode, toggleTheme } = useTheme();
+
+  return (
+    <Box>
+      <Button onClick={toggleTheme}>
+        {isDarkMode ? "Switch to light" : "Switch to dark"}
+      </Button>
+    </Box>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <RejoiceProvider defaultTheme="light">
+    <App />
+  </RejoiceProvider>
+);
+```
+
+## Included features
+
+- React exports from a single package surface
+- `RejoiceProvider` for Ant Design + styled-components theme wiring
+- `useTheme` and persisted dark/light mode state
+- Ant Design component exports
+- Zustand store helpers and middleware exports
+- styled-components exports including `styled`, `css`, and `createGlobalStyle`
+
+## Scaffolding
+
+If you want a ready-made starter app instead of wiring this manually, use [`create-rejoice-app`](https://www.npmjs.com/package/create-rejoice-app).

--- a/packages/rejoice/package.json
+++ b/packages/rejoice/package.json
@@ -1,6 +1,7 @@
 {
   "name": "rejoice-js",
   "version": "0.1.0",
+  "description": "A batteries-included React package that re-exports React with Ant Design, styled-components, Zustand, and built-in theme utilities.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -27,7 +28,25 @@
       "types": "./dist/jsx-dev-runtime.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
+  "keywords": [
+    "react",
+    "antd",
+    "styled-components",
+    "zustand",
+    "theme",
+    "design-system"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AviroopPaul/rejoice-js.git",
+    "directory": "packages/rejoice"
+  },
+  "homepage": "https://github.com/AviroopPaul/rejoice-js#readme",
+  "bugs": {
+    "url": "https://github.com/AviroopPaul/rejoice-js/issues"
+  },
+  "license": "MIT",
   "peerDependencies": { "react": "^18.0.0", "react-dom": "^18.0.0" },
   "dependencies": {
     "antd": "^5.17.0",


### PR DESCRIPTION
Description:
Add package-level README files and npm metadata so both published packages show setup guidance, basic features, and repository details on npm.

Why:
Both create-rejoice-app and rejoice-js currently render blank npm pages because the published packages do not include package-specific README content or description metadata. This change prepares the package contents so the next explicit release can populate npm correctly.

Files touched:
packages/create-rejoice-app/README.md
packages/create-rejoice-app/package.json
packages/rejoice/README.md
packages/rejoice/package.json

Type of change:
low