### PR TITLE
docs: use @latest tag in all bunx commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A batteries-included React meta-framework. Scaffold a full Bun-powered project with [Ant Design 5](https://ant.design), [styled-components](https://styled-components.com), [Zustand](https://zustand-demo.pmnd.rs), [Lucide Icons](https://lucide.dev), and dark/light mode — all wired and working from the first line.
 
 ```bash
-bunx create-rejoice-app my-app
+bunx create-rejoice-app@latest my-app
 cd my-app
 bun install && bun dev
 ```
@@ -34,15 +34,15 @@ bun install && bun dev
 ### Scaffolding
 
 ```bash
-bunx create-rejoice-app my-app
+bunx create-rejoice-app@latest my-app
 # or
-bunx create-rejoice-app         # interactive prompts
+bunx create-rejoice-app@latest         # interactive prompts
 ```
 
 Every prompt can be skipped with CLI flags for non-interactive use (agents, CI):
 
 ```bash
-bunx create-rejoice-app my-app --router --theme dark --git
+bunx create-rejoice-app@latest my-app --router --theme dark --git
 ```
 
 | Flag          | Description                       | Default |

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -509,14 +509,14 @@ def get_project_overview() -> str:
 
 **Quick start:**
 ```bash
-bunx create-rejoice-app my-app
+bunx create-rejoice-app@latest my-app
 cd my-app
 bun install && bun dev
 ```
 
 **Non-interactive (for agents/CI):**
 ```bash
-bunx create-rejoice-app my-app --router --theme light --git
+bunx create-rejoice-app@latest my-app --router --theme light --git
 ```
 Flags: `--router`/`--no-router`, `--theme light|dark`, `--git`/`--no-git`. When all flags + name are provided, no prompts are shown.
 

--- a/packages/create-rejoice-app/README.md
+++ b/packages/create-rejoice-app/README.md
@@ -16,7 +16,7 @@ The generated app comes prewired with:
 ## Quick start
 
 ```bash
-bunx create-rejoice-app my-app
+bunx create-rejoice-app@latest my-app
 cd my-app
 bun install
 bun dev
@@ -25,7 +25,7 @@ bun dev
 You can also run it without arguments and answer the prompts:
 
 ```bash
-bunx create-rejoice-app
+bunx create-rejoice-app@latest
 ```
 
 ## CLI flags
@@ -33,7 +33,7 @@ bunx create-rejoice-app
 Every interactive prompt can be skipped with a flag, making the CLI fully non-interactive for AI agents and CI:
 
 ```bash
-bunx create-rejoice-app my-app --router --theme dark --git
+bunx create-rejoice-app@latest my-app --router --theme dark --git
 ```
 
 | Flag          | Description                       | Default |
@@ -48,7 +48,7 @@ When all flags are provided along with the project name, no prompts are shown:
 
 ```bash
 # Fully non-interactive — ideal for agents and scripts
-bunx create-rejoice-app my-app --no-router --theme light --no-git
+bunx create-rejoice-app@latest my-app --no-router --theme light --no-git
 ```
 
 ## What the CLI asks for (interactive mode)

--- a/website/docs.html
+++ b/website/docs.html
@@ -106,7 +106,7 @@
                 <span class="code-block-lang">terminal</span>
                 <button class="code-copy-btn" aria-label="Copy code">Copy</button>
               </div>
-              <pre><code>bunx create-rejoice-app my-app
+              <pre><code>bunx create-rejoice-app@latest my-app
 cd my-app
 bun install
 bun dev</code></pre>
@@ -131,41 +131,60 @@ bun dev</code></pre>
                 The scaffolder uses Bun as the default runtime and bundler.
               </p>
             </div>
-            <h3>CLI Options</h3>
-            <p>The interactive prompts ask for:</p>
+            <h3>CLI Flags</h3>
+            <p>
+              Every prompt can be skipped with a flag, making the CLI fully non-interactive for AI
+              agents and CI:
+            </p>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-block-lang">terminal</span>
+                <button class="code-copy-btn" aria-label="Copy code">Copy</button>
+              </div>
+              <pre><code>bunx create-rejoice-app@latest my-app --router --theme dark --git</code></pre>
+            </div>
             <div class="props-table-wrap">
               <table class="props-table">
                 <thead>
                   <tr>
-                    <th>Option</th>
+                    <th>Flag</th>
                     <th>Default</th>
                     <th>Description</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
-                    <td><code>Project name</code></td>
-                    <td>CLI argument or prompt</td>
-                    <td>Must be a valid npm package name</td>
-                  </tr>
-                  <tr>
-                    <td><code>Include React Router</code></td>
+                    <td><code>--router</code></td>
                     <td><code>true</code></td>
-                    <td>Adds <code>react-router-dom</code> v6 with sample routes</td>
+                    <td>Include React Router v6</td>
                   </tr>
                   <tr>
-                    <td><code>Default theme</code></td>
+                    <td><code>--no-router</code></td>
+                    <td>—</td>
+                    <td>Skip React Router</td>
+                  </tr>
+                  <tr>
+                    <td><code>--theme light|dark</code></td>
                     <td><code>"light"</code></td>
                     <td>Sets the initial theme for <code>RejoiceProvider</code></td>
                   </tr>
                   <tr>
-                    <td><code>Initialize git</code></td>
+                    <td><code>--git</code></td>
                     <td><code>true</code></td>
-                    <td>Runs <code>git init</code> with an initial commit</td>
+                    <td>Initialize a git repository</td>
+                  </tr>
+                  <tr>
+                    <td><code>--no-git</code></td>
+                    <td>—</td>
+                    <td>Skip git init</td>
                   </tr>
                 </tbody>
               </table>
             </div>
+            <p>
+              When all flags are provided along with the project name, no prompts are shown. Flags
+              not provided will fall back to interactive prompts.
+            </p>
           </section>
 
           <div class="divider"></div>

--- a/website/index.html
+++ b/website/index.html
@@ -34,7 +34,7 @@
       <div class="install-block">
         <div class="install-cmd" id="installCmd">
           <span class="install-prompt">$</span>
-          <code>bunx create-rejoice-app your_app_name</code>
+          <code>bunx create-rejoice-app@latest your_app_name</code>
         </div>
         <button class="copy-btn" id="copyBtn" aria-label="Copy install command">
           <svg

--- a/website/script.js
+++ b/website/script.js
@@ -3,7 +3,7 @@ const copyBtn = document.getElementById("copyBtn");
 const copyLabel = document.getElementById("copyLabel");
 
 copyBtn.addEventListener("click", () => {
-  navigator.clipboard.writeText("bunx create-rejoice-app your_app_name").then(() => {
+  navigator.clipboard.writeText("bunx create-rejoice-app@latest your_app_name").then(() => {
     copyLabel.textContent = "Copied!";
     setTimeout(() => {
       copyLabel.textContent = "Copy";


### PR DESCRIPTION
## Summary
- Update all `bunx create-rejoice-app` commands to `bunx create-rejoice-app@latest` across the website, READMEs, and MCP server
- Add CLI flags reference table to the GitHub Pages docs page (`docs.html`)

## Why
`bunx` caches packages locally. Users who previously ran an older version get the stale cached copy instead of the latest release. Using `@latest` forces bun to always pull the newest version.

## Files touched
- `website/index.html` — hero install command
- `website/script.js` — copy-to-clipboard text
- `website/docs.html` — installation command + replaced "CLI Options" interactive prompts table with "CLI Flags" table
- `README.md` — all scaffolding examples
- `packages/create-rejoice-app/README.md` — all scaffolding examples
- `mcp/server.py` — `get_project_overview()` quick-start commands

## Type of change: `low`

## Test plan
- [ ] Verify website renders correctly with updated commands
- [ ] Verify copy button copies the `@latest` command
- [ ] Verify CLI flags table displays correctly on docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)